### PR TITLE
Add enable JUTConsole global flag

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -34,4 +34,6 @@ SECTIONS
 
         ICInvalidateRange = 0x80079CAC;
         DCInvalidateRange = 0x80079B54;
+
+        game_first_move = 0x80404C68;
 }

--- a/linker.ld
+++ b/linker.ld
@@ -35,5 +35,5 @@ SECTIONS
         ICInvalidateRange = 0x80079CAC;
         DCInvalidateRange = 0x80079B54;
 
-        game_first_move = 0x80404C68;
+        game_move_first = 0x80404C68;
 }

--- a/source/main.c
+++ b/source/main.c
@@ -8,7 +8,7 @@ extern void* nesinfo_data_start;
 extern void* my_malloc_current[2];
 extern void* my_zelda_malloc_align(unsigned long size, int align);
 extern void my_zelda_free(void *ptr);
-extern void* game_first_move;
+extern void* game_move_first;
 
 void load_patches(void *patch_data) {
     // flag bits reserved for future use
@@ -20,8 +20,8 @@ void load_patches(void *patch_data) {
     // check if enable JUTConsole flag is set, and enable it if so
     if (global_flags & 1) {
         OSReport("enabling JUTConsole without zurumode");
-        *(uint32_t*) (game_first_move + 6 * sizeof(uint32_t)) = 0x60000000; // nop the branch if equal
-        ICInvalidateRange(game_first_move, 0x20);
+        *((uint32_t *)&game_move_first + 6) = 0x60000000; // nop the branch if equal
+        ICInvalidateRange(game_move_first, 0x20);
     }
 
     // get number of patches to load

--- a/source/main.c
+++ b/source/main.c
@@ -20,7 +20,7 @@ void load_patches(void *patch_data) {
     // check if enable JUTConsole flag is set, and enable it if so
     if (global_flags & 1) {
         OSReport("enabling JUTConsole without zurumode");
-        *(uint32_t*) (game_first_move + 0x18) = 0x60000000; // nop the branch if equal
+        *(uint32_t*) (game_first_move + 6 * sizeof(uint32_t)) = 0x60000000; // nop the branch if equal
     }
 
     // get number of patches to load

--- a/source/main.c
+++ b/source/main.c
@@ -22,6 +22,7 @@ void load_patches(void *patch_data) {
         OSReport("enabling JUTConsole without zurumode");
         *((uint32_t *)&game_move_first + 6) = 0x60000000; // nop the branch if equal
         ICInvalidateRange(game_move_first, 0x20);
+        JUTReportConsole("JUT Console is now enabled!");
     }
 
     // get number of patches to load

--- a/source/main.c
+++ b/source/main.c
@@ -8,6 +8,7 @@ extern void* nesinfo_data_start;
 extern void* my_malloc_current[2];
 extern void* my_zelda_malloc_align(unsigned long size, int align);
 extern void my_zelda_free(void *ptr);
+extern void* game_first_move;
 
 void load_patches(void *patch_data) {
     // flag bits reserved for future use
@@ -15,6 +16,12 @@ void load_patches(void *patch_data) {
     patch_data += sizeof(global_flags);
 
     OSReport("global flags: 0x%x",  global_flags);
+
+    // check if enable JUTConsole flag is set, and enable it if so
+    if (global_flags & 1) {
+        OSReport("enabling JUTConsole without zurumode");
+        *(uint32_t*) (game_first_move + 0x18) = 0x60000000; // nop the branch if equal
+    }
 
     // get number of patches to load
     uint16_t num_patches = *(uint16_t*) patch_data;

--- a/source/main.c
+++ b/source/main.c
@@ -21,6 +21,7 @@ void load_patches(void *patch_data) {
     if (global_flags & 1) {
         OSReport("enabling JUTConsole without zurumode");
         *(uint32_t*) (game_first_move + 6 * sizeof(uint32_t)) = 0x60000000; // nop the branch if equal
+        ICInvalidateRange(game_first_move, 0x20);
     }
 
     // get number of patches to load

--- a/source/main.c
+++ b/source/main.c
@@ -8,7 +8,7 @@ extern void* nesinfo_data_start;
 extern void* my_malloc_current[2];
 extern void* my_zelda_malloc_align(unsigned long size, int align);
 extern void my_zelda_free(void *ptr);
-extern void* game_move_first;
+extern void* game_move_first(void *current_graph_process_data);
 
 void load_patches(void *patch_data) {
     // flag bits reserved for future use


### PR DESCRIPTION
When the lowest bit is set, the patcher will now enable the JUT Console for developers to see debug prints in, all without enabling zurumode itself.